### PR TITLE
exfat: fix wrong return value in exfat_utf8_d_cmp

### DIFF
--- a/fs/exfat/namei.c
+++ b/fs/exfat/namei.c
@@ -196,7 +196,7 @@ static int exfat_utf8_d_cmp(const struct dentry *dentry, unsigned int len,
 		}
 	}
 
-	return 1;
+	return 0;
 }
 
 const struct dentry_operations exfat_utf8_dentry_ops = {


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>